### PR TITLE
Add extract-changelog script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
+gem 'immutable-struct', '~> 2.4'
+gem 'kramdown', '~> 2.1'
+
 group :development, :test do
   gem 'bundler', '~> 1.17'
   gem 'rake', '~> 13.0'

--- a/bin/extract-changelog
+++ b/bin/extract-changelog
@@ -1,0 +1,140 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'getoptlong'
+require 'immutable-struct'
+require 'kramdown'
+
+VESION_REGEX = /v(?<version>\d(?:[\d\.]*\d)?)/.freeze
+
+VERSION = '0.1'
+
+ChangelogVersion = ImmutableStruct.new(:version, :raw_version, [:content])
+
+def usage
+  warn <<~USAGE
+    usage: #{File.basename(__FILE__)} [options]
+      -h, --help                      print help
+      --version                       print the version
+      -v, --verbose                   verbose logging
+      -i, --in-file [path]            path to input markdown file, otherwise use stdin
+      -o, --out-file [path]           path to output markdown file, otherwise use stdout
+      -u, --upto-version [version]    collect all version changelogs up to this version_only
+      -s, --single-version [version]  output only changelog for this version
+  USAGE
+end
+
+opts = GetoptLong.new(
+  ['--help', '-h', GetoptLong::NO_ARGUMENT],
+  ['--verbose', '-v', GetoptLong::NO_ARGUMENT],
+  ['--version', GetoptLong::NO_ARGUMENT],
+  ['--in-file', '-i', GetoptLong::REQUIRED_ARGUMENT],
+  ['--out-file', '-o', GetoptLong::REQUIRED_ARGUMENT],
+  ['--upto-version', '-u', GetoptLong::REQUIRED_ARGUMENT],
+  ['--single-version', '-s', GetoptLong::REQUIRED_ARGUMENT],
+)
+
+verbose = false
+in_file_path = nil
+out_file_path = nil
+upto_version = nil
+single_version = nil
+
+opts.each do |opt, arg|
+  case opt
+  when '--help'
+    usage
+    exit
+  when '--version'
+    puts VERSION
+    exit
+  when '--verbose'
+    verbose = true
+  when '--in-file'
+    in_file_path = arg
+  when '--out-file'
+    out_file_path = arg
+  when '--upto-version'
+    upto_version = arg
+  when '--single-version'
+    single_version = arg
+  end
+end
+
+raise 'Cannot use both upto-version and single-version' if upto_version && single_version
+raise 'Need upto-version or single-version' if upto_version.nil? && single_version.nil?
+
+in_file_contents = in_file_path.nil? ? $stdin.read : File.read(in_file_path)
+
+raise 'input is empty!' if in_file_contents.strip.empty?
+
+document = Kramdown::Document.new(in_file_contents)
+
+changelog_versions = []
+current_version = nil
+
+document.root.children.each do |child|
+  if child.type == :header && child.children[0].value =~ VESION_REGEX
+    raw_version = child.children[0].value
+    version_match = raw_version.match VESION_REGEX
+    current_version = ChangelogVersion.new(version: Gem::Version.new(version_match[:version]), raw_version: raw_version)
+    changelog_versions << current_version
+  elsif child.type == :header
+    current_version = nil
+  elsif current_version
+    current_version.content << child
+  end
+end
+
+changelog_versions.each do |content:, **|
+  content.shift while content.first.type == :blank
+  content.pop while content.last.type == :blank
+end
+
+if single_version
+  selected_versions = changelog_versions.select do |version|
+    version.raw_version == single_version
+  end
+
+  raise "No versions found matching #{single_version}" if selected_versions.empty?
+
+  if selected_versions.size > 1
+    raise "Too many (#{selected_versions.size}) versions found matching #{single_version} (expected exactly one)"
+  end
+elsif upto_version
+  version_match = upto_version.match VESION_REGEX
+  current_version = Gem::Version.new(version_match[:version])
+  selected_versions = changelog_versions.select do |version|
+    version.version <= current_version
+  end
+
+  selected_versions.sort! do |v1, v2|
+    -(v1.version <=> v2.version)
+  end
+
+  raise "No versions found up to #{upto_version}" if selected_versions.empty?
+  raise "First version is not #{upto_version}" if selected_versions.first.raw_version != upto_version
+else
+  raise 'nothing to do!'
+end
+
+new_root = Kramdown::Element.new(:root, nil, nil, encoding: Encoding::UTF_8)
+
+selected_versions.each do |changelog_version|
+  header = Kramdown::Element.new(:header, nil, nil, level: 3)
+  header.children << Kramdown::Element.new(:text, changelog_version.raw_version)
+  new_root.children << header
+  new_root.children << Kramdown::Element.new(:blank, "\n")
+  new_root.children.concat changelog_version.content
+  new_root.children << Kramdown::Element.new(:blank, "\n")
+end
+
+result = Kramdown::Converter::Kramdown.convert(new_root).first
+
+result = result.delete_suffix("\n") while result.end_with? "\n\n"
+
+if out_file_path
+  File.write(out_file_path, result)
+else
+  puts result
+end

--- a/spec/extract_changelog_spec.rb
+++ b/spec/extract_changelog_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'open3'
+require 'tempfile'
+
+VERSION_DATA = <<~MARKDOWN
+  # Changelog
+
+  some text
+
+  ### v1.1.1
+
+  * fix a bug
+  * fix another bug
+
+  ### v1.1.0
+
+  * add a feature
+  * fix a bug
+
+  ### v1.0.0
+
+  * Initial release
+MARKDOWN
+
+RSpec.describe 'fill-version' do
+  command = File.join(Dir.pwd, 'bin', 'extract-changelog').freeze
+
+  it 'prints version to STDOUT on --version' do
+    output, _, status = Open3.capture3("#{command} --version")
+    expect(status.success?).to be(true)
+    expect(output.strip).to match(/[\d\.]+/)
+  end
+
+  it 'prints help to STDERR on --help' do
+    stdout, stderr, status = Open3.capture3("#{command} --help")
+    expect(status.success?).to be(true)
+    expect(stdout).to be_empty
+    expect(stderr).to match(/usage:/)
+  end
+
+  it 'gets all the versions up to a particular version' do
+    output, _, status = Open3.capture3("#{command} --upto-version v1.1.0", stdin_data: VERSION_DATA)
+    expect(status.success?).to be(true)
+
+    expected_output = <<~MARKDOWN
+      ### v1.1.0
+
+      * add a feature
+      * fix a bug
+
+      ### v1.0.0
+
+      * Initial release
+    MARKDOWN
+    expect(output).to eq(expected_output)
+  end
+
+  it 'gets just one version' do
+    output, _, status = Open3.capture3("#{command} --single-version v1.1.0", stdin_data: VERSION_DATA)
+    expect(status.success?).to be(true)
+
+    expected_output = <<~MARKDOWN
+      ### v1.1.0
+
+      * add a feature
+      * fix a bug
+    MARKDOWN
+    expect(output).to eq(expected_output)
+  end
+
+  it 'uses an input file' do
+    Tempfile.open(['changelog', '.md']) do |tempfile|
+      tempfile.write VERSION_DATA
+      tempfile.flush
+      output, _, status = Open3.capture3("#{command} -s v1.1.0 --in-file '#{tempfile.path}'")
+      expect(status.success?).to be(true)
+
+      expected_output = <<~MARKDOWN
+        ### v1.1.0
+
+        * add a feature
+        * fix a bug
+      MARKDOWN
+      expect(output).to eq(expected_output)
+    end
+  end
+
+  it 'uses an output file' do
+    Tempfile.open(['changelog', '.md']) do |tempfile|
+      output, _, status = Open3.capture3("#{command} -s v1.1.0 --out-file '#{tempfile.path}'", stdin_data: VERSION_DATA)
+      expect(status.success?).to be(true)
+      expect(output).to be_empty
+
+      expected_output = <<~MARKDOWN
+        ### v1.1.0
+
+        * add a feature
+        * fix a bug
+      MARKDOWN
+      expect(File.read(tempfile.path)).to eq(expected_output)
+    end
+  end
+
+  it 'complains if both upto version and single version are specified' do
+    _, _, status = Open3.capture3("#{command} -s v1.1.0 -u v1.1.0", stdin_data: VERSION_DATA)
+    expect(status.success?).to be(false)
+  end
+
+  it 'complains if neither upto version and single version are specified' do
+    _, _, status = Open3.capture3(command, stdin_data: VERSION_DATA)
+    expect(status.success?).to be(false)
+  end
+
+  it 'complains with empty input' do
+    _, _, status = Open3.capture3("#{command} --single-version v1.1.0")
+    expect(status.success?).to be(false)
+  end
+
+  it 'complains with an input version that is not matched' do
+    _, _, status = Open3.capture3("#{command} --single-version v1.0.1", stdin_data: VERSION_DATA)
+    expect(status.success?).to be(false)
+  end
+
+  it 'complains with a version upto that matches other versions but not that exact version' do
+    _, _, status = Open3.capture3("#{command} --single-version v1.0.1", stdin_data: VERSION_DATA)
+    expect(status.success?).to be(false)
+  end
+
+  it 'complains with a version upto that matches no version' do
+    _, _, status = Open3.capture3("#{command} --single-version v0.9", stdin_data: VERSION_DATA)
+    expect(status.success?).to be(false)
+  end
+end


### PR DESCRIPTION
reads markdown input and extracts just a single version or all versions up to a particular version